### PR TITLE
Add initial support for PGVector

### DIFF
--- a/Backend/requirements.txt
+++ b/Backend/requirements.txt
@@ -140,6 +140,7 @@ tiktoken==0.8.0
 regex==2024.11.6
 langchain-openai==0.2.14
 langchain-chroma==0.2.1
+pgvector==0.3.6
 langchain-postgres>=0.0.13
 psycopg[c,binary,pool]==3.2.5
 SQLAlchemy==2.0.38

--- a/Backend/requirements.txt
+++ b/Backend/requirements.txt
@@ -141,6 +141,7 @@ regex==2024.11.6
 langchain-openai==0.2.14
 langchain-chroma==0.2.1
 pgvector==0.3.6
+langchain-ollama==0.2.3
 langchain-postgres>=0.0.13
 psycopg[c,binary,pool]==3.2.5
 SQLAlchemy==2.0.38

--- a/Backend/requirements.txt
+++ b/Backend/requirements.txt
@@ -140,6 +140,8 @@ tiktoken==0.8.0
 regex==2024.11.6
 langchain-openai==0.2.14
 langchain-chroma==0.2.1
+langchain-postgres>=0.0.13
+psycopg[binary,pool]==3.2.5
 psutil==6.1.1
 ollama==0.4.4
 docx2txt==0.8

--- a/Backend/requirements.txt
+++ b/Backend/requirements.txt
@@ -141,7 +141,8 @@ regex==2024.11.6
 langchain-openai==0.2.14
 langchain-chroma==0.2.1
 langchain-postgres>=0.0.13
-psycopg[binary,pool]==3.2.5
+psycopg[c,binary,pool]==3.2.5
+SQLAlchemy==2.0.38
 psutil==6.1.1
 ollama==0.4.4
 docx2txt==0.8

--- a/Backend/src/config.py
+++ b/Backend/src/config.py
@@ -35,8 +35,8 @@ _vectorstorage = {
     'postgresPassword': None,
     'postgresHost': 'localhost',
     'postgresPort': 5432,
-    'postgresVectorDatabase': None,
-    'postgresVectorTable': 'vectors',
+    'postgresVectorDatabase': 'embeddings',
+    'postgresVectorTable': 'default',
 
     'embeddingProviders': ['ollama'],    
     'defaultEmbeddingProvider': None,

--- a/Backend/src/config.py
+++ b/Backend/src/config.py
@@ -1,0 +1,70 @@
+_authentication = {}
+
+_data = {}
+
+_endpoint = {
+    # embed.py
+    'embeddingsProvider': None,
+    'warnFileSize': 26214400, # 25MB
+    'maxFileSize': 26214400, # 25MB
+    # models.py
+    'localEmbeddingModel': 'granite-embedding:278m'
+}
+
+_llms = {
+    'providers': {
+        # ollama.py
+        'ollamaHost': 'localhost',
+        'ollamaPort': 11434
+    }
+}
+
+_models = {}
+
+_vectorstorage = {
+    # Common
+    'max_seq_length': 512,
+    # TODO impliment
+    'vectorStores': [
+        'ChromaDB',
+        'PGVector'
+    ],
+    'defaultVectorStore': 'ChromaDB',
+    # Postgres
+    'postgresUser': 'postgres',
+    'postgresPassword': None,
+    'postgresHost': 'localhost',
+    'postgresPort': 5432,
+    'postgresVectorDatabase': None,
+    'postgresVectorTable': 'vectors',
+
+    'embeddingProviders': ['ollama'],    
+    'defaultEmbeddingProvider': None,
+    # init_store.py and vectorstore.py
+    'embeddingModels': [
+        'HIT-TMG/KaLM-embedding-multilingual-mini-instruct-v1.5',
+        'nomic-ai/nomic-embed-text-v1',
+        'Snowflake/snowflake-arctic-embed-l-v2.0'
+    ],
+    'defaultLocalEmbeddingModel': 'HIT-TMG/KaLM-embedding-multilingual-mini-instruct-v1.5',
+    'embeddingModelsDir': None,
+    # embeddings.py
+    'embed_chunk_keepLast': 5,
+    'embed_chunk-minChunkNum': 20,
+    'embed_chunk-enoughDataPoints': 3
+}
+
+_voice = {}
+
+
+config = {
+    'authentication': _authentication,
+    'data': _data,
+    'endpoint': _endpoint,
+    'llms': _llms,
+    'models': _models,
+    'vectorstorage': _vectorstorage,
+    'voice': _voice
+}
+
+

--- a/Backend/src/vectorstorage/vectorstore.py
+++ b/Backend/src/vectorstorage/vectorstore.py
@@ -2,7 +2,7 @@ from src.vectorstorage.init_store import get_models_dir
 from langchain_huggingface import HuggingFaceEmbeddings
 from langchain_chroma import Chroma
 from langchain_openai import OpenAIEmbeddings
-
+from langchain_ollama import OllamaEmbeddings
 
 import torch
 import os
@@ -79,7 +79,9 @@ def get_embeddings(embeddings_provider: str = None, api_key: str = None):
     
     elif embeddings_provider == "ollama":
         logger.info(f"Using Ollama model: {ollama_embedding_model}")
-        # TODO
+        embeddings = OllamaEmbeddings(
+            model="snowflake-arctic-embed2" # TODO put in config.py
+        )
 
     elif embeddings_provider == "OpenAI":
         logger.info("Using OpenAI embedding model")
@@ -175,17 +177,18 @@ def get_vectorstore(
         collection_name: str, 
         use_local_embeddings: bool = False, 
         local_embedding_model: str = "HIT-TMG/KaLM-embedding-multilingual-mini-instruct-v1.5", # unused, moved to config.py
-        which_vectorstore: str = 'ChromaDB'):
+        which_vectorstore: str = 'ChromaDB',
+        embeddings_provider: str = 'OpenAI'):
 
     try:
         # Get embeddings
         embeddings = None
 
-        # At the moment this maintains the original behavior, changing the config.py does not do anything.
-        if use_local_embeddings or api_key is None:
+        # TODO improve the logic
+        if (use_local_embeddings or api_key is None) and embeddings_provider != 'ollama':
             embeddings = get_embeddings()
         else:
-            embeddings = get_embeddings(embeddings_provider='OpenAI', api_key=api_key)
+            embeddings = get_embeddings(embeddings_provider=embeddings_provider, api_key=api_key)
 
         # Try to create vectorstore with specific settings
         vectorstore = None

--- a/Backend/src/vectorstorage/vectorstore.py
+++ b/Backend/src/vectorstorage/vectorstore.py
@@ -79,11 +79,11 @@ def get_embeddings(embeddings_provider: str = None, api_key: str = None):
     
     elif embeddings_provider == "ollama":
         logger.info(f"Using Ollama model: {ollama_embedding_model}")
+        # TODO
 
-    elif embeddings_provider == "openAPI":
+    elif embeddings_provider == "OpenAI":
         logger.info("Using OpenAI embedding model")
         embeddings = OpenAIEmbeddings(api_key=api_key)
-
 
     return embeddings
 
@@ -176,19 +176,16 @@ def get_vectorstore(
         use_local_embeddings: bool = False, 
         local_embedding_model: str = "HIT-TMG/KaLM-embedding-multilingual-mini-instruct-v1.5", # unused, moved to config.py
         which_vectorstore: str = 'ChromaDB'):
-    
+
     try:
         # Get embeddings
         embeddings = None
 
-        # At the moment this maintains the original behavior, changing the configuration does not do anything.
+        # At the moment this maintains the original behavior, changing the config.py does not do anything.
         if use_local_embeddings or api_key is None:
             embeddings = get_embeddings()
         else:
-            logger.info("Using OpenAI embedding model")
-            embeddings = OpenAIEmbeddings(api_key=api_key)
-
-        embeddings = get_embeddings(api_key=api_key)
+            embeddings = get_embeddings(embeddings_provider='OpenAI', api_key=api_key)
 
         # Try to create vectorstore with specific settings
         vectorstore = None

--- a/Backend/src/vectorstorage/vectorstore.py
+++ b/Backend/src/vectorstorage/vectorstore.py
@@ -2,10 +2,13 @@ from src.vectorstorage.init_store import get_models_dir
 from langchain_huggingface import HuggingFaceEmbeddings
 from langchain_chroma import Chroma
 from langchain_openai import OpenAIEmbeddings
+# from langchain_postgres import PGVector
+# from langchain_postgres.vectorstores import PGVector
 import torch
 import os
 import logging
 import platform
+from src.config import config
 
 logger = logging.getLogger(__name__)
 
@@ -24,108 +27,174 @@ def get_app_data_dir():
 chroma_db_path = os.path.join(get_app_data_dir(), "chroma_db")
 logger.info(f"Using Chroma DB path: {chroma_db_path}")
 
-def get_vectorstore(api_key: str, collection_name: str, use_local_embeddings: bool = False, local_embedding_model: str = "HIT-TMG/KaLM-embedding-multilingual-mini-instruct-v1.5"):
-    try:
-        # Get embeddings
-        if use_local_embeddings or api_key is None:
-            logger.info(f"Using local embedding model: {local_embedding_model}")
-            
-            # Determine the appropriate device
-            if torch.cuda.is_available():
-                device = "cuda"
-            elif hasattr(torch.backends, 'mps') and torch.backends.mps.is_available():
-                device = "mps"
-            else:
-                device = "cpu"
-                
-            logger.info(f"Using device: {device}")
-            models_dir = get_models_dir()
-            logger.info(f"Using models directory: {models_dir}")
 
-            model_kwargs = {"device": device}
-            encode_kwargs = {
-                "device": device,
-                "normalize_embeddings": True,
-                "max_seq_length": 512
-            }
+# Should this be renamed to "get_embedder" since this is not really getting the actual embeddings of the data
+def get_embeddings(embeddings_provider: str = None, api_key: str = None):
+    embeddings = None
 
-            try:
+    local_embedding_model: str = config['vectorstorage']['defaultLocalEmbeddingModel']
+
+    if (embeddings_provider == None) or (embeddings_provider == 'local'):
+        logger.info(f"Using local embedding model: {local_embedding_model}")
+        
+        # Determine the appropriate device
+        device = "cpu"
+        if torch.cuda.is_available():
+            device = "cuda"
+        elif hasattr(torch.backends, 'mps') and torch.backends.mps.is_available():
+            device = "mps"    
+        logger.info(f"Using device: {device}")
+
+        models_dir = get_models_dir()
+        logger.info(f"Using models directory: {models_dir}")
+
+        model_kwargs = {"device": device}
+        encode_kwargs = {
+            "device": device,
+            "normalize_embeddings": True,
+            "max_seq_length": 512
+        }
+
+        try:
+            embeddings = HuggingFaceEmbeddings(
+                model_name=local_embedding_model,
+                model_kwargs=model_kwargs,
+                encode_kwargs=encode_kwargs,
+                cache_folder=models_dir
+            )
+        except Exception as e:
+            logger.error(f"Error initializing embeddings with {device}: {str(e)}")
+            if device != "cpu":
+                logger.info("Falling back to CPU")
+                model_kwargs["device"] = "cpu"
+                encode_kwargs["device"] = "cpu"
                 embeddings = HuggingFaceEmbeddings(
                     model_name=local_embedding_model,
                     model_kwargs=model_kwargs,
                     encode_kwargs=encode_kwargs,
                     cache_folder=models_dir
                 )
-            except Exception as e:
-                logger.error(f"Error initializing embeddings with {device}: {str(e)}")
-                if device != "cpu":
-                    logger.info("Falling back to CPU")
-                    model_kwargs["device"] = "cpu"
-                    encode_kwargs["device"] = "cpu"
-                    embeddings = HuggingFaceEmbeddings(
-                        model_name=local_embedding_model,
-                        model_kwargs=model_kwargs,
-                        encode_kwargs=encode_kwargs,
-                        cache_folder=models_dir
-                    )
-                else:
-                    raise
+            else:
+                raise
+    
+    elif embeddings_provider == "ollama":
+        logger.info(f"Using Ollama model: {ollama_embedding_model}")
+
+    elif embeddings_provider == "openAPI":
+        logger.info("Using OpenAI embedding model")
+        embeddings = OpenAIEmbeddings(api_key=api_key)
+
+
+    return embeddings
+
+
+def get_chromaDB_vectorstore(embedding_function, collection_name):
+    try:
+        from chromadb.config import Settings
+        import chromadb
+
+        # Use in-memory store if persistent store fails
+        try:
+            chroma_client = chromadb.PersistentClient(
+                path=chroma_db_path,
+                settings=Settings(
+                    anonymized_telemetry=False,
+                    allow_reset=True,
+                    is_persistent=True
+                )
+            )
+        except Exception as e:
+            logger.warning(f"Failed to create persistent client: {str(e)}, falling back to in-memory")
+            chroma_client = chromadb.Client(
+                settings=Settings(
+                    anonymized_telemetry=False,
+                    allow_reset=True,
+                    is_persistent=False
+                )
+            )
+
+        vectorstore = Chroma(
+            client=chroma_client,
+            embedding_function=embedding_function,
+            collection_name=collection_name,
+        )
+        logger.info(f"Successfully initialized vectorstore for collection: {collection_name}")
+        
+        return vectorstore
+    except Exception as e:
+        logger.error(f"Error creating Chroma instance: {str(e)}")
+        # Try one more time with in-memory store
+        try:
+            chroma_client = chromadb.Client(
+                settings=Settings(
+                    anonymized_telemetry=False,
+                    allow_reset=True,
+                    is_persistent=False
+                )
+            )
+            vectorstore = Chroma(
+                client=chroma_client,
+                embedding_function=embedding_function,
+                collection_name=collection_name,
+            )
+            return vectorstore
+        except Exception as e2:
+            logger.error(f"Error creating in-memory Chroma instance: {str(e2)}")
+            return None
+
+def get_PGVector_vectorstore(embedding_function, table):
+
+    user = config['vectorstorage']['postgresUser']
+    password = config['vectorstorage']['postgresPassword']
+    host = config['vectorstorage']['postgresHost']
+    port = config['vectorstorage']['postgresPort']
+    db = config['vectorstorage']['postgresVectorDatabase']
+
+    connection = f"postgresql+psycopg://{user}:{password}@{host}:{port}/{db}"  # Uses psycopg3!
+
+    table = config['vectorstorage']['postgresVectorTable']
+
+    vector_store = PGVector(
+        embeddings=embedding_function,
+        collection_name=table,
+        connection=connection,
+        use_jsonb=True,
+    )
+
+    return vector_store
+
+def get_vectorstore(
+        api_key: str, 
+        collection_name: str, 
+        use_local_embeddings: bool = False, 
+        local_embedding_model: str = "HIT-TMG/KaLM-embedding-multilingual-mini-instruct-v1.5", # unused, moved to config.py
+        which_vectorstore: str = 'ChromaDB'):
+    
+    try:
+        # Get embeddings
+        embeddings = None
+
+        # At the moment this maintains the original behavior, changing the configucation does not do anything.
+        if use_local_embeddings or api_key is None:
+            embeddings = get_embeddings()
         else:
             logger.info("Using OpenAI embedding model")
             embeddings = OpenAIEmbeddings(api_key=api_key)
 
+        embeddings = get_embeddings(api_key=api_key)
+
         # Try to create vectorstore with specific settings
-        try:
-            from chromadb.config import Settings
-            import chromadb
+        vectorstore = None
 
-            # Use in-memory store if persistent store fails
-            try:
-                chroma_client = chromadb.PersistentClient(
-                    path=chroma_db_path,
-                    settings=Settings(
-                        anonymized_telemetry=False,
-                        allow_reset=True,
-                        is_persistent=True
-                    )
-                )
-            except Exception as e:
-                logger.warning(f"Failed to create persistent client: {str(e)}, falling back to in-memory")
-                chroma_client = chromadb.Client(
-                    settings=Settings(
-                        anonymized_telemetry=False,
-                        allow_reset=True,
-                        is_persistent=False
-                    )
-                )
+        if which_vectorstore == 'ChromaDB':
+            vectorstore = get_chromaDB_vectorstore(embedding_function=embeddings, collection_name=collection_name)
+        elif which_vectorstore == 'PGVector':
+            vectorstore = get_PGVector_vectorstore(embedding_function=embeddings, table=collection_name)
+        else:
+            raise Exception("Unsupported parameter for 'which_vectorstore', valid parameters are, 'ChromaDB' and 'PGVector'")
 
-            vectorstore = Chroma(
-                client=chroma_client,
-                embedding_function=embeddings,
-                collection_name=collection_name,
-            )
-            logger.info(f"Successfully initialized vectorstore for collection: {collection_name}")
-            return vectorstore
-        except Exception as e:
-            logger.error(f"Error creating Chroma instance: {str(e)}")
-            # Try one more time with in-memory store
-            try:
-                chroma_client = chromadb.Client(
-                    settings=Settings(
-                        anonymized_telemetry=False,
-                        allow_reset=True,
-                        is_persistent=False
-                    )
-                )
-                vectorstore = Chroma(
-                    client=chroma_client,
-                    embedding_function=embeddings,
-                    collection_name=collection_name,
-                )
-                return vectorstore
-            except Exception as e2:
-                logger.error(f"Error creating in-memory Chroma instance: {str(e2)}")
-                return None
+        return vectorstore
+
 
     except Exception as e:
         logger.error(f"Error getting vectorstore: {str(e)}")

--- a/Backend/src/vectorstorage/vectorstore.py
+++ b/Backend/src/vectorstorage/vectorstore.py
@@ -78,9 +78,11 @@ def get_embeddings(embeddings_provider: str = None, api_key: str = None):
                 raise
     
     elif embeddings_provider == "ollama":
+        ollama_embedding_model = "snowflake-arctic-embed2" # TODO put in config.py
+
         logger.info(f"Using Ollama model: {ollama_embedding_model}")
         embeddings = OllamaEmbeddings(
-            model="snowflake-arctic-embed2" # TODO put in config.py
+            model = ollama_embedding_model
         )
 
     elif embeddings_provider == "OpenAI":

--- a/Frontend/package.json
+++ b/Frontend/package.json
@@ -24,7 +24,10 @@
     "transpile:electron": "tsc --project src/electron/tsconfig.json",
     "dist:mac": "npm run transpile:electron && npm run build && electron-builder --mac --arm64",
     "dist:win": "npm run transpile:electron && npm run build && electron-builder --win --x64 --publish never",
-    "dist:linux": "npm run transpile:electron && npm run build && electron-builder --linux --x64"
+    "dist:linux": "npm run transpile:electron && npm run build && electron-builder --linux --x64",
+    "start": "electron .",
+    "rebuild": "electron-rebuild -f -w better-sqlite3",
+    "postinstall": "electron-builder install-app-deps"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.32.1",


### PR DESCRIPTION
Changes:
Fix NODE_MODULE_VERSION error from "better-sqlite3"

Refactor get_vectorstore() into separate functions:
get_embeddings()
get_chromaDB_vectorstore(), this is the original but separated into a function of it's own.
get_PGVector_vectorstore(), this provides support for PGVector as the vectorstore

Add which_vectorstore to the function signature of get_vectorstore() to specify if ChromaDB or PGVector should be used.

Create config.py where various parameters for the backend can be set instead of being hardcoded.